### PR TITLE
177 s3 upload

### DIFF
--- a/nodeServer/TESTING.md
+++ b/nodeServer/TESTING.md
@@ -12,20 +12,20 @@ Build the test image (this will install dependencies inside the image):
 
 ```bash
 # build the test image using the dedicated compose file
-docker compose -f docker-compose.test.yml build node-server-test
+cd .. && docker compose -f docker-compose.test.yml build node-server-test
 ```
 
 Run the tests (runs `npm ci` then `npm test` inside the container):
 
 ```bash
-docker compose -f docker-compose.test.yml run --rm node-server-test
+cd .. && docker compose -f docker-compose.test.yml run --rm node-server-test
 ```
 
 Alternative CI-friendly command (build and run, then exit when complete):
 
 ```bash
 # starts container, runs tests and stops
-docker compose -f docker-compose.test.yml up --build --abort-on-container-exit node-server-test
+cd .. && docker compose -f docker-compose.test.yml up --build --abort-on-container-exit node-server-test
 ```
 
 Notes

--- a/nodeServer/app.js
+++ b/nodeServer/app.js
@@ -13,6 +13,7 @@ import login from './routes/login.js';
 import map from './routes/map.js';
 import dataManagement from './routes/dataManagement.js';
 import users from './routes/users.js';
+import uploads from './routes/uploads.js';
 
 import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -59,6 +60,7 @@ app.use('/login', login);
 app.use('/map', map);
 app.use('/dataManagement', dataManagement);
 app.use('/users', users);
+app.use('/uploads', uploads);
 
 app.use(logger('dev'));
 

--- a/nodeServer/package-lock.json
+++ b/nodeServer/package-lock.json
@@ -8,6 +8,7 @@
       "name": "UBHub",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "3.616.0",
         "bcryptjs": "3.0.3",
         "body-parser": "2.2.1",
         "client-sessions": "0.8.0",
@@ -15,6 +16,7 @@
         "express": "5.2.1",
         "express-session": "1.18.2",
         "morgan": "1.10.1",
+        "multer": "2.1.1",
         "mysql2": "3.16.0",
         "nodemailer": "6.9.4",
         "pug": "3.0.3",
@@ -30,6 +32,916 @@
       "engines": {
         "node": "22.21.1",
         "npm": "10.9.4"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.616.0.tgz",
+      "integrity": "sha512-6gyZnBlAgOU8cwNqPhFO9s6maGI4/iHV3cmqvQgUn3uqhi1EgTSZSsTMuRzKEgBpTGgC+9Bm6djKqOderMqjdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/client-sts": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.616.0",
+        "@aws-sdk/middleware-expect-continue": "3.616.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-location-constraint": "3.609.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-sdk-s3": "3.616.0",
+        "@aws-sdk/middleware-signing": "3.616.0",
+        "@aws-sdk/middleware-ssec": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/signature-v4-multi-region": "3.616.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@aws-sdk/xml-builder": "3.609.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+        "@smithy/eventstream-serde-node": "^3.0.4",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-blob-browser": "^3.1.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/hash-stream-node": "^3.1.2",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/md5-js": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-stream": "^3.1.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
+      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
+      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.616.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
+      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.616.0",
+        "@aws-sdk/core": "3.616.0",
+        "@aws-sdk/credential-provider-node": "3.616.0",
+        "@aws-sdk/middleware-host-header": "3.616.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.616.0",
+        "@aws-sdk/middleware-user-agent": "3.616.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.2.7",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.4",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-retry": "^3.0.10",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.10",
+        "@smithy/util-defaults-mode-node": "^3.0.10",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
+      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.2.7",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
+      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
+      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.2",
+        "@smithy/node-http-handler": "^3.1.3",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
+      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.616.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
+      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.609.0",
+        "@aws-sdk/credential-provider-http": "3.616.0",
+        "@aws-sdk/credential-provider-ini": "3.616.0",
+        "@aws-sdk/credential-provider-process": "3.614.0",
+        "@aws-sdk/credential-provider-sso": "3.616.0",
+        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
+      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
+      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.616.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
+      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.609.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.616.0.tgz",
+      "integrity": "sha512-KZv78s8UE7+s3qZCfG3pE9U9XV5WTP478aNWis5gDXmsb5LF7QWzEeR8kve5dnjNlK6qVQ33v+mUZa6lR5PwMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.616.0.tgz",
+      "integrity": "sha512-IM1pfJPm7pDUXa55js9bnGjS8o3ldzDwf95mL9ZAYdEsm10q6i0ZxZbbro2gTq25Ap5ykdeeS34lOSzIqPiW1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.616.0.tgz",
+      "integrity": "sha512-Mrco/dURoTXVqwcnYRcyrFaPTIg36ifg2PK0kUYfSVTGEOClZOQXlVG5zYCZoo3yEMgy/gLT907FjUQxwoifIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
+      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
+      "integrity": "sha512-xzsdoTkszGVqGVPjUmgoP7TORiByLueMHieI1fhQL888WPdqctwAx3ES6d/bA9Q/i8jnc6hs+Fjhy8UvBTkE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
+      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.616.0.tgz",
+      "integrity": "sha512-heq9pzn0NRX6VL/oMlmwZdgcCh5eJUDscvwMl/oGev0tNdTpB2oGU+wPaNMka7IrW3eBPn7APmY9fdS1kBaBoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-stream": "^3.1.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.616.0.tgz",
+      "integrity": "sha512-wwzZFlXyURwo40oz1NmufreQa5DqwnCF8hR8tIP5+oKCyhbkmlmv8xG4Wn51bzY2WEbQhvFebgZSFTEvelCoCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
+      "integrity": "sha512-GZSD1s7+JswWOTamVap79QiDaIV7byJFssBW68GYjyRS5EBjNfwA/8s+6uE6g39R3ojyTbYOmvcANoZEhSULXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
+      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.616.0.tgz",
+      "integrity": "sha512-WQn43cfnwbG6jnPjh/SyujDQVqbRjGFY9tGI/tqtUvvGwoDhI343TSDCA7fvs0FEC6Za6vgOBq1CwPv3CFyfhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.616.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/signature-v4": "^4.0.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+      "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
+      "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -979,6 +1891,709 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.7.tgz",
+      "integrity": "sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.10.tgz",
+      "integrity": "sha512-323B8YckSbUH0nMIpXn7HZsAVKHYHFUODa8gG9cHo0ySvA1fr5iWaNT+iIL0UCqUzG6QPHA3BSsBtRQou4mMqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.14.tgz",
+      "integrity": "sha512-kbrt0vjOIihW3V7Cqj1SXQvAI5BR8SnyQYsandva0AOR307cXAc+IhPngxIPslxTLfxwDpNu0HzCAq6g42kCPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.11.tgz",
+      "integrity": "sha512-P2pnEp4n75O+QHjyO7cbw/vsw5l93K/8EWyjNCAAybYwUmj3M+hjSQZ9P5TVdUgEG08ueMAP5R4FkuSkElZ5tQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.13.tgz",
+      "integrity": "sha512-zqy/9iwbj8Wysmvi7Lq7XFLeDgjRpTbCfwBhJa8WbrylTAHiAu6oQTwdY7iu2lxigbc9YYr9vPv5SzYny5tCXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.13.tgz",
+      "integrity": "sha512-L1Ib66+gg9uTnqp/18Gz4MDpJPKRE44geOjOQ2SVc0eiaO5l255ADziATZgjQjqumC7yPtp1XnjHlF1srcwjKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^3.1.10",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.10.tgz",
+      "integrity": "sha512-elwslXOoNunmfS0fh55jHggyhccobFkexLYC1ZeZ1xP2BTSrcIBaHV2b4xUQOdctrSNOpMqOZH1r2XzWTEhyfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.10.tgz",
+      "integrity": "sha512-olomK/jZQ93OMayW1zfTHwcbwBdhcZOHsyWyiZ9h9IXvc1mCD/VuvzbLb3Gy/qNJwI4MANPLctTp2BucV2oU/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.11.tgz",
+      "integrity": "sha512-3NM0L3i2Zm4bbgG6Ymi9NBcxXhryi3uE8fIfHJZIOfZVxOkGdjdgjR9A06SFIZCfnEIWKXZdm6Yq5/aPXFFhsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.8.tgz",
+      "integrity": "sha512-OEJZKVUEhMOqMs3ktrTWp7UvvluMJEvD5XgQwRePSbDg1VvBaL8pX8mwPltFn6wk1GySbcVwwyldL8S+iqnrEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.34.tgz",
+      "integrity": "sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.7.0.tgz",
+      "integrity": "sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-endpoint": "^3.2.8",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.34.tgz",
+      "integrity": "sha512-FumjjF631lR521cX+svMLBj3SwSDh9VdtyynTYDAiBDEf8YPP5xORNXKQ9j0105o5+ARAGnOOP/RqSl40uXddA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.34.tgz",
+      "integrity": "sha512-vN6aHfzW9dVVzkI0wcZoUXvfjkl4CSbM9nE//08lmUMyf00S75uuCpTrqF9uD4bD9eldIXlt53colrlwKAT8Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.4.tgz",
+      "integrity": "sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.3",
+        "@smithy/node-http-handler": "^3.3.3",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+      "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.2.0.tgz",
+      "integrity": "sha512-PpjSboaDUE6yl+1qlg3Si57++e84oXdWGbuFUSAciXsVfEZJJJupR2Nb0QuXHiunt2vGR+1PTizOMvnUPaG2Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1188,6 +2803,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "license": "MIT"
@@ -1300,6 +2921,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1438,6 +3082,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/confbox": {
@@ -1999,6 +3658,28 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -2811,6 +4492,68 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.16.0",
       "license": "MIT",
@@ -3328,6 +5071,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "license": "MIT",
@@ -3795,6 +5552,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -3833,6 +5607,18 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -3915,6 +5701,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
@@ -3950,6 +5742,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typo-js": {
       "version": "1.3.1",
@@ -4005,6 +5803,25 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/nodeServer/package-lock.json
+++ b/nodeServer/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.616.0",
+        "@aws-sdk/s3-request-presigner": "3.616.0",
         "bcryptjs": "3.0.3",
         "body-parser": "2.2.1",
         "client-sessions": "0.8.0",
@@ -808,6 +809,25 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.616.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.616.0.tgz",
+      "integrity": "sha512-C5ADFHTBCPGw+W3XNvS7vZdCY2LtRbcw05hu34xxhNlDXatOAPE4O22uRfiaZq12Lu0Qq8ylNYnD8I28r7I4Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.616.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-format-url": "3.609.0",
+        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/protocol-http": "^4.0.4",
+        "@smithy/smithy-client": "^3.1.8",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.616.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.616.0.tgz",
@@ -878,6 +898,21 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.609.0.tgz",
+      "integrity": "sha512-fuk29BI/oLQlJ7pfm6iJ4gkEpHdavffAALZwXh9eaY1vQ0ip0aKfRTiNudPoJjyyahnz5yJ1HkmlcDitlzsOrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/nodeServer/package.json
+++ b/nodeServer/package.json
@@ -25,7 +25,9 @@
     "request": "2.88.2",
     "sass": "1.94.2",
     "serve-favicon": "2.5.1",
-    "simplemde": "1.11.2"
+    "simplemde": "1.11.2",
+    "@aws-sdk/client-s3": "3.616.0",
+    "multer": "1.4.5"
   },
   "devDependencies": {
     "vitest": "1.0.0",

--- a/nodeServer/package.json
+++ b/nodeServer/package.json
@@ -27,6 +27,7 @@
     "serve-favicon": "2.5.1",
     "simplemde": "1.11.2",
     "@aws-sdk/client-s3": "3.616.0",
+    "@aws-sdk/s3-request-presigner": "3.616.0",
     "multer": "2.1.1"
   },
   "devDependencies": {

--- a/nodeServer/package.json
+++ b/nodeServer/package.json
@@ -27,7 +27,7 @@
     "serve-favicon": "2.5.1",
     "simplemde": "1.11.2",
     "@aws-sdk/client-s3": "3.616.0",
-    "multer": "1.4.5"
+    "multer": "2.1.1"
   },
   "devDependencies": {
     "vitest": "1.0.0",

--- a/nodeServer/public/javascripts/data-management/modalManager.js
+++ b/nodeServer/public/javascripts/data-management/modalManager.js
@@ -207,9 +207,7 @@ export class ModalRenderer {
               const formData = new FormData();
               formData.append('file', file);
 
-              // Optionally provide a prefix based on selected table to help with organization in the bucket
-              const prefix = (manager && manager.selectedTable) ? manager.selectedTable : '';
-              const uploadUrl = prefix ? `/uploads?prefix=${encodeURIComponent(prefix)}` : '/uploads';
+              const uploadUrl = '/uploads';
 
               const resp = await fetch(uploadUrl, { method: 'POST', body: formData });
               if (!resp.ok) {

--- a/nodeServer/public/javascripts/data-management/modalManager.js
+++ b/nodeServer/public/javascripts/data-management/modalManager.js
@@ -185,8 +185,9 @@ export class ModalRenderer {
           statusSpan.style.marginLeft = '8px';
           rowDiv.appendChild(statusSpan);
 
-          // Upload handler: POST to /uploads as multipart/form-data and set the returned URL
           uploadButton.addEventListener('click', async () => {
+            const maximumFileSizeBytes = 50 * 1024 * 1024;
+            const multipartThresholdBytes = 10 * 1024 * 1024;
             try {
               statusSpan.textContent = '';
               if (!fileInput.files || fileInput.files.length === 0) {
@@ -194,38 +195,168 @@ export class ModalRenderer {
                 return;
               }
               const file = fileInput.files[0];
-              // Basic client-side validation for PDF
-              const nameLower = (file.name || '').toLowerCase();
-              if (!(file.type === 'application/pdf' || nameLower.endsWith('.pdf'))) {
+              const normalizedFileName = (file.name || '').toLowerCase();
+              if (!(file.type === 'application/pdf' || normalizedFileName.endsWith('.pdf'))) {
                 statusSpan.textContent = 'Only PDF files are allowed';
+                return;
+              }
+              if (file.size > maximumFileSizeBytes) {
+                statusSpan.textContent = 'File exceeds maximum allowed size';
                 return;
               }
 
               uploadButton.disabled = true;
               statusSpan.textContent = 'Uploading...';
 
-              const formData = new FormData();
-              formData.append('file', file);
+              const uploadWithPresignedUrl = async () => {
+                const presignResponse = await fetch('/uploads/presign', {
+                  method: 'POST',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({
+                    fileName: file.name,
+                    contentType: file.type || 'application/pdf',
+                    fileSize: file.size,
+                  }),
+                });
 
-              const uploadUrl = '/uploads';
+                if (!presignResponse.ok) {
+                  const errorText = await presignResponse.text().catch(() => 'Presign request failed');
+                  throw new Error(errorText);
+                }
 
-              const resp = await fetch(uploadUrl, { method: 'POST', body: formData });
-              if (!resp.ok) {
-                const text = await resp.text().catch(() => 'Upload failed');
-                throw new Error(text || ('HTTP ' + resp.status));
+                const presignBody = await presignResponse.json();
+                if (!presignBody || !presignBody.url || !presignBody.key) {
+                  throw new Error('Presign response missing upload URL');
+                }
+
+                const putResponse = await fetch(presignBody.url, {
+                  method: 'PUT',
+                  headers: {'Content-Type': file.type || 'application/pdf'},
+                  body: file,
+                });
+
+                if (!putResponse.ok) {
+                  const errorText = await putResponse.text().catch(() => 'S3 upload failed');
+                  throw new Error(errorText || `S3 upload failed with status ${putResponse.status}`);
+                }
+
+                const uploadedObjectUrl = presignBody.objectUrl || presignBody.url.split('?')[0];
+                urlInput.value = uploadedObjectUrl;
+              };
+
+              const uploadWithMultipart = async () => {
+                const initiationResponse = await fetch('/uploads/multipart/initiate', {
+                  method: 'POST',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({
+                    fileName: file.name,
+                    contentType: file.type || 'application/pdf',
+                    fileSize: file.size,
+                  }),
+                });
+
+                if (!initiationResponse.ok) {
+                  const errorText = await initiationResponse.text().catch(() => 'Multipart initiation failed');
+                  throw new Error(errorText);
+                }
+
+                const initiationBody = await initiationResponse.json();
+                const partSizeBytes = initiationBody.partSizeBytes || (8 * 1024 * 1024);
+                const uploadParts = [];
+
+                const abortUpload = async () => {
+                  try {
+                    await fetch('/uploads/multipart/abort', {
+                      method: 'POST',
+                      headers: {'Content-Type': 'application/json'},
+                      body: JSON.stringify({uploadId: initiationBody.uploadId, key: initiationBody.key}),
+                    });
+                  } catch (abortError) {
+                    console.error('Error aborting multipart upload:', abortError);
+                  }
+                };
+
+                for (let partOffset = 0, partNumber = 1; partOffset < file.size; partNumber += 1, partOffset += partSizeBytes) {
+                  const fileChunk = file.slice(partOffset, Math.min(partOffset + partSizeBytes, file.size));
+
+                  const presignPartResponse = await fetch('/uploads/multipart/part-url', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                      uploadId: initiationBody.uploadId,
+                      key: initiationBody.key,
+                      partNumber,
+                    }),
+                  });
+
+                  if (!presignPartResponse.ok) {
+                    const errorText = await presignPartResponse.text().catch(() => 'Failed to create part URL');
+                    await abortUpload();
+                    throw new Error(errorText);
+                  }
+
+                  const presignPartBody = await presignPartResponse.json();
+                  if (!presignPartBody || !presignPartBody.url) {
+                    await abortUpload();
+                    throw new Error('Missing part upload URL');
+                  }
+
+                  const partUploadResponse = await fetch(presignPartBody.url, {
+                    method: 'PUT',
+                    body: fileChunk,
+                  });
+
+                  if (!partUploadResponse.ok) {
+                    const errorText = await partUploadResponse.text().catch(() => 'Part upload failed');
+                    await abortUpload();
+                    throw new Error(errorText || `Part upload failed with status ${partUploadResponse.status}`);
+                  }
+
+                  const entityTag = partUploadResponse.headers.get('ETag') || partUploadResponse.headers.get('etag');
+                  if (!entityTag) {
+                    await abortUpload();
+                    throw new Error('Missing ETag for uploaded part');
+                  }
+
+                  uploadParts.push({partNumber, eTag: entityTag});
+                  statusSpan.textContent = `Uploaded part ${partNumber}`;
+                }
+
+                const completionResponse = await fetch('/uploads/multipart/complete', {
+                  method: 'POST',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({
+                    uploadId: initiationBody.uploadId,
+                    key: initiationBody.key,
+                    parts: uploadParts,
+                  }),
+                });
+
+                if (!completionResponse.ok) {
+                  const errorText = await completionResponse.text().catch(() => 'Multipart completion failed');
+                  await abortUpload();
+                  throw new Error(errorText);
+                }
+
+                const completionBody = await completionResponse.json();
+                const completedObjectUrl = completionBody.location || initiationBody.objectUrl;
+                if (!completedObjectUrl) {
+                  throw new Error('Multipart completion did not return object URL');
+                }
+
+                urlInput.value = completedObjectUrl;
+              };
+
+              if (file.size > multipartThresholdBytes) {
+                await uploadWithMultipart();
+                statusSpan.textContent = 'Uploaded with multipart';
+              } else {
+                await uploadWithPresignedUrl();
+                statusSpan.textContent = 'Uploaded';
               }
-
-              const body = await resp.json().catch(() => null);
-              if (!body || !body.url) {
-                throw new Error('No URL returned from upload');
-              }
-
-              // Populate the URL input so it's included in the pending-change payload
-              urlInput.value = body.url;
-              statusSpan.textContent = 'Uploaded';
-            } catch (err) {
-              console.error('Upload error:', err);
-              try { statusSpan.textContent = 'Upload failed: ' + (err.message || ''); } catch (_) {}
+            } catch (error) {
+              console.error('Upload error:', error);
+              try { statusSpan.textContent = 'Upload failed: ' + (error.message || ''); } catch (_) {}
             } finally {
               uploadButton.disabled = false;
             }

--- a/nodeServer/public/javascripts/data-management/modalManager.js
+++ b/nodeServer/public/javascripts/data-management/modalManager.js
@@ -153,14 +153,95 @@ export class ModalRenderer {
         rowDiv.appendChild(hiddenInput);
         rowDiv.appendChild(resultsDiv);
       } else {
-        const inputElement = document.createElement('input');
-        inputElement.type = 'text';
-        inputElement.id = `${column.name}`;
-        inputElement.name = column.name;
-        inputElement.setAttribute('data-col-name', column.name);
-        inputElement.placeholder = `Enter ${labelText}`;
-        inputElement.className = 'dataManagementInput';
-        rowDiv.appendChild(inputElement);
+        // Special-case document URL field: provide a text input that will hold the final
+        // document URL and an adjacent file input + upload button for PDFs. The text
+        // input uses `data-col-name` so existing form submission logic picks it up.
+        if (column.name === 'doc_url') {
+          const urlInput = document.createElement('input');
+          urlInput.type = 'text';
+          urlInput.id = `${column.name}`;
+          urlInput.name = column.name;
+          urlInput.setAttribute('data-col-name', column.name);
+          urlInput.placeholder = `Enter ${labelText} or upload a PDF`;
+          urlInput.className = 'dataManagementInput';
+          rowDiv.appendChild(urlInput);
+
+          const fileInput = document.createElement('input');
+          fileInput.type = 'file';
+          fileInput.accept = 'application/pdf';
+          fileInput.id = `file_${column.name}`;
+          fileInput.className = 'dataManagementFileInput';
+          rowDiv.appendChild(fileInput);
+
+          const uploadButton = document.createElement('button');
+          uploadButton.type = 'button';
+          uploadButton.textContent = 'Upload PDF';
+          uploadButton.className = 'primary';
+          rowDiv.appendChild(uploadButton);
+
+          const statusSpan = document.createElement('span');
+          statusSpan.id = `status_${column.name}`;
+          statusSpan.className = 'upload-status';
+          statusSpan.style.marginLeft = '8px';
+          rowDiv.appendChild(statusSpan);
+
+          // Upload handler: POST to /uploads as multipart/form-data and set the returned URL
+          uploadButton.addEventListener('click', async () => {
+            try {
+              statusSpan.textContent = '';
+              if (!fileInput.files || fileInput.files.length === 0) {
+                statusSpan.textContent = 'No file selected';
+                return;
+              }
+              const file = fileInput.files[0];
+              // Basic client-side validation for PDF
+              const nameLower = (file.name || '').toLowerCase();
+              if (!(file.type === 'application/pdf' || nameLower.endsWith('.pdf'))) {
+                statusSpan.textContent = 'Only PDF files are allowed';
+                return;
+              }
+
+              uploadButton.disabled = true;
+              statusSpan.textContent = 'Uploading...';
+
+              const formData = new FormData();
+              formData.append('file', file);
+
+              // Optionally provide a prefix based on selected table to help with organization in the bucket
+              const prefix = (manager && manager.selectedTable) ? manager.selectedTable : '';
+              const uploadUrl = prefix ? `/uploads?prefix=${encodeURIComponent(prefix)}` : '/uploads';
+
+              const resp = await fetch(uploadUrl, { method: 'POST', body: formData });
+              if (!resp.ok) {
+                const text = await resp.text().catch(() => 'Upload failed');
+                throw new Error(text || ('HTTP ' + resp.status));
+              }
+
+              const body = await resp.json().catch(() => null);
+              if (!body || !body.url) {
+                throw new Error('No URL returned from upload');
+              }
+
+              // Populate the URL input so it's included in the pending-change payload
+              urlInput.value = body.url;
+              statusSpan.textContent = 'Uploaded';
+            } catch (err) {
+              console.error('Upload error:', err);
+              try { statusSpan.textContent = 'Upload failed: ' + (err.message || ''); } catch (_) {}
+            } finally {
+              uploadButton.disabled = false;
+            }
+          });
+        } else {
+          const inputElement = document.createElement('input');
+          inputElement.type = 'text';
+          inputElement.id = `${column.name}`;
+          inputElement.name = column.name;
+          inputElement.setAttribute('data-col-name', column.name);
+          inputElement.placeholder = `Enter ${labelText}`;
+          inputElement.className = 'dataManagementInput';
+          rowDiv.appendChild(inputElement);
+        }
       }
 
       fieldsContainer.appendChild(rowDiv);

--- a/nodeServer/routes/uploads.js
+++ b/nodeServer/routes/uploads.js
@@ -25,10 +25,7 @@ router.post('/', isAuthenticated, upload.single('file'), async (request, respons
 
     const file = request.file;
 
-    // Construct a safe key for the object. Optionally a prefix can be set
-    // via query param or config — keep this minimal for now.
-    const prefix = request.query.prefix || '';
-    const key = makeObjectKey(file.originalname, prefix);
+    const key = makeObjectKey(file.originalname);
 
     const result = await uploadBufferToS3(s3Client, config.S3_BUCKET, key, file.buffer, file.mimetype, config.S3_PUBLIC_READ);
 

--- a/nodeServer/routes/uploads.js
+++ b/nodeServer/routes/uploads.js
@@ -82,7 +82,7 @@ router.post('/presign', isAuthenticated, async (request, response) => {
     });
   } catch (error) {
     console.error('Error creating presigned PUT URL:', error);
-    return response.status(500).json({error: 'Failed to create presigned URL', details: error.message});
+    return response.status(500).json({error: 'Failed to create presigned URL'});
   }
 });
 
@@ -125,7 +125,7 @@ router.post('/multipart/initiate', isAuthenticated, async (request, response) =>
     });
   } catch (error) {
     console.error('Error initiating multipart upload:', error);
-    return response.status(500).json({error: 'Failed to initiate multipart upload', details: error.message});
+    return response.status(500).json({error: 'Failed to initiate multipart upload'});
   }
 });
 
@@ -165,7 +165,7 @@ router.post('/multipart/part-url', isAuthenticated, async (request, response) =>
     });
   } catch (error) {
     console.error('Error creating presigned upload part URL:', error);
-    return response.status(500).json({error: 'Failed to create presigned part URL', details: error.message});
+    return response.status(500).json({error: 'Failed to create presigned part URL'});
   }
 });
 
@@ -211,7 +211,7 @@ router.post('/multipart/complete', isAuthenticated, async (request, response) =>
     });
   } catch (error) {
     console.error('Error completing multipart upload:', error);
-    return response.status(500).json({error: 'Failed to complete multipart upload', details: error.message});
+    return response.status(500).json({error: 'Failed to complete multipart upload'});
   }
 });
 
@@ -241,7 +241,7 @@ router.post('/multipart/abort', isAuthenticated, async (request, response) => {
     });
   } catch (error) {
     console.error('Error aborting multipart upload:', error);
-    return response.status(500).json({error: 'Failed to abort multipart upload', details: error.message});
+    return response.status(500).json({error: 'Failed to abort multipart upload'});
   }
 });
 
@@ -269,7 +269,7 @@ router.post('/', isAuthenticated, upload.single('file'), async (request, respons
     if (error.code === 'MISSING_BUCKET') {
       return response.status(500).json({error: 'S3 bucket is not configured on the server'});
     }
-    return response.status(500).json({error: 'Upload error', details: error.message});
+    return response.status(500).json({error: 'Upload error'});
   }
 });
 

--- a/nodeServer/routes/uploads.js
+++ b/nodeServer/routes/uploads.js
@@ -1,0 +1,51 @@
+import express from 'express';
+import multer from 'multer';
+import config from '../config.js';
+import {createS3Client, uploadBufferToS3, makeObjectKey} from '../services/s3UploadService.js';
+import {isAuthenticated} from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+// Use memory storage for small uploads; this keeps the file in memory as a
+// Buffer which we then pass to the S3 SDK. For large files consider using
+// streaming or presigned URLs.
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: config.S3_MAX_FILE_SIZE },
+});
+
+const s3Client = createS3Client(config);
+
+// POST /uploads - expects multipart/form-data with field 'file'
+router.post('/', isAuthenticated, upload.single('file'), async (request, response) => {
+  try {
+    if (!request.file) {
+      return response.status(400).json({error: 'No file provided under field "file"'});
+    }
+
+    const file = request.file;
+
+    // Construct a safe key for the object. Optionally a prefix can be set
+    // via query param or config — keep this minimal for now.
+    const prefix = request.query.prefix || '';
+    const key = makeObjectKey(file.originalname, prefix);
+
+    const result = await uploadBufferToS3(s3Client, config.S3_BUCKET, key, file.buffer, file.mimetype, config.S3_PUBLIC_READ);
+
+    return response.status(201).json({
+      success: true,
+      bucket: result.bucket,
+      key: result.key,
+      url: result.url,
+    });
+  } catch (error) {
+    console.error('Error uploading file to S3:', error);
+    if (error.code === 'MISSING_BUCKET') {
+      return response.status(500).json({error: 'S3 bucket is not configured on the server'});
+    }
+    return response.status(500).json({error: 'Upload error', details: error.message});
+  }
+});
+
+export default router;
+

--- a/nodeServer/routes/uploads.js
+++ b/nodeServer/routes/uploads.js
@@ -1,7 +1,16 @@
 import express from 'express';
 import multer from 'multer';
 import config from '../config.js';
-import {createS3Client, uploadBufferToS3, makeObjectKey} from '../services/s3UploadService.js';
+import {
+  createS3Client,
+  uploadBufferToS3,
+  makeObjectKey,
+  createPresignedPutUrl,
+  initiateMultipartUpload,
+  createPresignedUploadPartUrl,
+  completeMultipartUpload,
+  abortMultipartUpload,
+} from '../services/s3UploadService.js';
 import {isAuthenticated} from '../middleware/authMiddleware.js';
 
 const router = express.Router();
@@ -15,6 +24,226 @@ const upload = multer({
 });
 
 const s3Client = createS3Client(config);
+
+function parsePositiveInteger(value) {
+  const parsedValue = Number(value);
+  if (Number.isNaN(parsedValue) || parsedValue <= 0) {
+    return null;
+  }
+  return parsedValue;
+}
+
+function validateFileSizeWithinLimits(fileSizeBytes) {
+  if (fileSizeBytes > config.S3_MAX_FILE_SIZE) {
+    return `File exceeds maximum allowed size of ${config.S3_MAX_FILE_SIZE} bytes`;
+  }
+  return null;
+}
+
+router.post('/presign', isAuthenticated, async (request, response) => {
+  try {
+    const {fileName, contentType = 'application/octet-stream', fileSize} = request.body;
+
+    if (!fileName) {
+      return response.status(400).json({error: 'fileName is required'});
+    }
+
+    const fileSizeBytes = parsePositiveInteger(fileSize);
+    if (!fileSizeBytes) {
+      return response.status(400).json({error: 'fileSize must be a positive number of bytes'});
+    }
+
+    const sizeValidationMessage = validateFileSizeWithinLimits(fileSizeBytes);
+    if (sizeValidationMessage) {
+      return response.status(400).json({error: sizeValidationMessage});
+    }
+
+    if (fileSizeBytes > config.S3_MULTIPART_THRESHOLD_BYTES) {
+      return response.status(400).json({error: 'File exceeds single-part upload threshold. Use multipart upload instead.'});
+    }
+
+    const objectKey = makeObjectKey(fileName);
+
+    const presignResult = await createPresignedPutUrl(s3Client, {
+      bucket: config.S3_BUCKET,
+      key: objectKey,
+      contentType,
+      expiresInSeconds: config.S3_PRESIGN_EXPIRATION_SECONDS,
+      publicRead: config.S3_PUBLIC_READ,
+    });
+
+    return response.status(200).json({
+      success: true,
+      bucket: presignResult.bucket,
+      key: presignResult.key,
+      url: presignResult.url,
+      expiresInSeconds: presignResult.expiresInSeconds,
+      objectUrl: presignResult.objectUrl,
+    });
+  } catch (error) {
+    console.error('Error creating presigned PUT URL:', error);
+    return response.status(500).json({error: 'Failed to create presigned URL', details: error.message});
+  }
+});
+
+router.post('/multipart/initiate', isAuthenticated, async (request, response) => {
+  try {
+    const {fileName, contentType = 'application/octet-stream', fileSize} = request.body;
+
+    if (!fileName) {
+      return response.status(400).json({error: 'fileName is required'});
+    }
+
+    const fileSizeBytes = parsePositiveInteger(fileSize);
+    if (!fileSizeBytes) {
+      return response.status(400).json({error: 'fileSize must be a positive number of bytes'});
+    }
+
+    const sizeValidationMessage = validateFileSizeWithinLimits(fileSizeBytes);
+    if (sizeValidationMessage) {
+      return response.status(400).json({error: sizeValidationMessage});
+    }
+
+    const objectKey = makeObjectKey(fileName);
+
+    const initiationResult = await initiateMultipartUpload(s3Client, {
+      bucket: config.S3_BUCKET,
+      key: objectKey,
+      contentType,
+      publicRead: config.S3_PUBLIC_READ,
+    });
+
+    return response.status(200).json({
+      success: true,
+      bucket: initiationResult.bucket,
+      key: initiationResult.key,
+      uploadId: initiationResult.uploadId,
+      objectUrl: initiationResult.objectUrl,
+      partSizeBytes: config.S3_MULTIPART_PART_SIZE_BYTES,
+      multipartThresholdBytes: config.S3_MULTIPART_THRESHOLD_BYTES,
+      presignedUrlExpirationSeconds: config.S3_PRESIGN_EXPIRATION_SECONDS,
+    });
+  } catch (error) {
+    console.error('Error initiating multipart upload:', error);
+    return response.status(500).json({error: 'Failed to initiate multipart upload', details: error.message});
+  }
+});
+
+router.post('/multipart/part-url', isAuthenticated, async (request, response) => {
+  try {
+    const {uploadId, key, partNumber} = request.body;
+
+    if (!uploadId) {
+      return response.status(400).json({error: 'uploadId is required'});
+    }
+
+    if (!key) {
+      return response.status(400).json({error: 'key is required'});
+    }
+
+    const parsedPartNumber = parsePositiveInteger(partNumber);
+    if (!parsedPartNumber) {
+      return response.status(400).json({error: 'partNumber must be a positive integer'});
+    }
+
+    const presignResult = await createPresignedUploadPartUrl(s3Client, {
+      bucket: config.S3_BUCKET,
+      key,
+      uploadId,
+      partNumber: parsedPartNumber,
+      expiresInSeconds: config.S3_PRESIGN_EXPIRATION_SECONDS,
+    });
+
+    return response.status(200).json({
+      success: true,
+      bucket: presignResult.bucket,
+      key: presignResult.key,
+      uploadId: presignResult.uploadId,
+      partNumber: presignResult.partNumber,
+      url: presignResult.url,
+      expiresInSeconds: presignResult.expiresInSeconds,
+    });
+  } catch (error) {
+    console.error('Error creating presigned upload part URL:', error);
+    return response.status(500).json({error: 'Failed to create presigned part URL', details: error.message});
+  }
+});
+
+router.post('/multipart/complete', isAuthenticated, async (request, response) => {
+  try {
+    const {uploadId, key, parts} = request.body;
+
+    if (!uploadId) {
+      return response.status(400).json({error: 'uploadId is required'});
+    }
+
+    if (!key) {
+      return response.status(400).json({error: 'key is required'});
+    }
+
+    if (!Array.isArray(parts) || parts.length === 0) {
+      return response.status(400).json({error: 'parts array with at least one item is required'});
+    }
+
+    const normalizedParts = parts.map((part) => ({
+      partNumber: Number(part.partNumber),
+      eTag: part.eTag,
+    })).filter((part) => !Number.isNaN(part.partNumber) && !!part.eTag);
+
+    if (normalizedParts.length !== parts.length) {
+      return response.status(400).json({error: 'Each part must include partNumber and eTag'});
+    }
+
+    const completionResult = await completeMultipartUpload(s3Client, {
+      bucket: config.S3_BUCKET,
+      key,
+      uploadId,
+      parts: normalizedParts,
+    });
+
+    return response.status(200).json({
+      success: true,
+      bucket: completionResult.bucket,
+      key: completionResult.key,
+      uploadId: completionResult.uploadId,
+      location: completionResult.location,
+      eTag: completionResult.eTag,
+    });
+  } catch (error) {
+    console.error('Error completing multipart upload:', error);
+    return response.status(500).json({error: 'Failed to complete multipart upload', details: error.message});
+  }
+});
+
+router.post('/multipart/abort', isAuthenticated, async (request, response) => {
+  try {
+    const {uploadId, key} = request.body;
+
+    if (!uploadId) {
+      return response.status(400).json({error: 'uploadId is required'});
+    }
+
+    if (!key) {
+      return response.status(400).json({error: 'key is required'});
+    }
+
+    const abortResult = await abortMultipartUpload(s3Client, {
+      bucket: config.S3_BUCKET,
+      key,
+      uploadId,
+    });
+
+    return response.status(200).json({
+      success: true,
+      bucket: abortResult.bucket,
+      key: abortResult.key,
+      uploadId: abortResult.uploadId,
+    });
+  } catch (error) {
+    console.error('Error aborting multipart upload:', error);
+    return response.status(500).json({error: 'Failed to abort multipart upload', details: error.message});
+  }
+});
 
 // POST /uploads - expects multipart/form-data with field 'file'
 router.post('/', isAuthenticated, upload.single('file'), async (request, response) => {

--- a/nodeServer/services/s3UploadService.js
+++ b/nodeServer/services/s3UploadService.js
@@ -1,6 +1,14 @@
-import {S3Client, PutObjectCommand} from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  PutObjectCommand,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+  AbortMultipartUploadCommand,
+} from '@aws-sdk/client-s3';
+import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
 import path from 'path';
-import config from "../config.js";
+import config from '../config.js';
 
 export function createS3Client(config) {
   const clientConfig = {
@@ -50,7 +58,7 @@ export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentTyp
 
   await s3Client.send(command);
 
-  const url = `https://${bucket}.s3.${config.AWS_REGION}.amazonaws.com/${encodeURI(key)}`;
+  const url = buildObjectUrl(bucket, key);
 
   return {bucket, key, url};
 }
@@ -59,10 +67,193 @@ export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentTyp
  * Helper to create a safe object key. Uses an optional folder/prefix and
  * the original file name. Time-based prefix reduces collisions.
  */
-export function makeObjectKey(originalName) {
-  const pathInBucket = 'public/pdfs/';
+export function makeObjectKey(originalName, keyPrefix = config.S3_KEY_PREFIX) {
+  const sanitizedPrefix = String(keyPrefix || '').replace(/^\//, '');
+  const normalizedPrefix = sanitizedPrefix.endsWith('/') ? sanitizedPrefix : `${sanitizedPrefix}/`;
   const timestamp = Date.now();
   const safeName = path.basename(String(originalName || '')).replace(/[^a-zA-Z0-9._-]/g, '_');
-  const key = `${pathInBucket}${timestamp}_${safeName}`;
-  return key;
+  return `${normalizedPrefix}${timestamp}_${safeName}`;
+}
+
+export async function createPresignedPutUrl(s3Client, options) {
+  const {bucket, key, contentType = 'application/octet-stream', expiresInSeconds = config.S3_PRESIGN_EXPIRATION_SECONDS, publicRead = true} = options;
+
+  if (!bucket) {
+    throw new Error('Bucket name is required');
+  }
+
+  if (!key) {
+    throw new Error('Object key is required');
+  }
+
+  const parameters = {
+    Bucket: bucket,
+    Key: key,
+    ContentType: contentType,
+  };
+
+  if (publicRead) {
+    parameters.ACL = 'public-read';
+  }
+
+  const command = new PutObjectCommand(parameters);
+  const url = await getSignedUrl(s3Client, command, {expiresIn: expiresInSeconds});
+
+  return {
+    bucket,
+    key,
+    url,
+    expiresInSeconds,
+    objectUrl: buildObjectUrl(bucket, key),
+  };
+}
+
+export async function initiateMultipartUpload(s3Client, options) {
+  const {bucket, key, contentType = 'application/octet-stream', publicRead = true} = options;
+
+  if (!bucket) {
+    throw new Error('Bucket name is required');
+  }
+
+  if (!key) {
+    throw new Error('Object key is required');
+  }
+
+  const parameters = {
+    Bucket: bucket,
+    Key: key,
+    ContentType: contentType,
+  };
+
+  if (publicRead) {
+    parameters.ACL = 'public-read';
+  }
+
+  const command = new CreateMultipartUploadCommand(parameters);
+  const response = await s3Client.send(command);
+
+  if (!response || !response.UploadId) {
+    throw new Error('Failed to initiate multipart upload');
+  }
+
+  return {
+    bucket,
+    key,
+    uploadId: response.UploadId,
+    objectUrl: buildObjectUrl(bucket, key),
+  };
+}
+
+export async function createPresignedUploadPartUrl(s3Client, options) {
+  const {bucket, key, uploadId, partNumber, expiresInSeconds = config.S3_PRESIGN_EXPIRATION_SECONDS} = options;
+
+  if (!bucket) {
+    throw new Error('Bucket name is required');
+  }
+
+  if (!key) {
+    throw new Error('Object key is required');
+  }
+
+  if (!uploadId) {
+    throw new Error('Upload ID is required');
+  }
+
+  if (!partNumber || Number.isNaN(Number(partNumber)) || Number(partNumber) < 1) {
+    throw new Error('Part number must be a positive integer');
+  }
+
+  const command = new UploadPartCommand({
+    Bucket: bucket,
+    Key: key,
+    UploadId: uploadId,
+    PartNumber: Number(partNumber),
+  });
+
+  const url = await getSignedUrl(s3Client, command, {expiresIn: expiresInSeconds});
+
+  return {
+    bucket,
+    key,
+    uploadId,
+    partNumber: Number(partNumber),
+    url,
+    expiresInSeconds,
+  };
+}
+
+export async function completeMultipartUpload(s3Client, options) {
+  const {bucket, key, uploadId, parts} = options;
+
+  if (!bucket) {
+    throw new Error('Bucket name is required');
+  }
+
+  if (!key) {
+    throw new Error('Object key is required');
+  }
+
+  if (!uploadId) {
+    throw new Error('Upload ID is required');
+  }
+
+  if (!Array.isArray(parts) || parts.length === 0) {
+    throw new Error('At least one uploaded part is required to complete the upload');
+  }
+
+  const sortedParts = [...parts].sort((firstPart, secondPart) => Number(firstPart.partNumber) - Number(secondPart.partNumber));
+
+  const uploadParts = sortedParts.map((part) => ({
+    ETag: part.eTag,
+    PartNumber: Number(part.partNumber),
+  }));
+
+  const command = new CompleteMultipartUploadCommand({
+    Bucket: bucket,
+    Key: key,
+    UploadId: uploadId,
+    MultipartUpload: {
+      Parts: uploadParts,
+    },
+  });
+
+  const response = await s3Client.send(command);
+
+  return {
+    bucket,
+    key,
+    uploadId,
+    location: response?.Location || buildObjectUrl(bucket, key),
+    eTag: response?.ETag,
+  };
+}
+
+export async function abortMultipartUpload(s3Client, options) {
+  const {bucket, key, uploadId} = options;
+
+  if (!bucket) {
+    throw new Error('Bucket name is required');
+  }
+
+  if (!key) {
+    throw new Error('Object key is required');
+  }
+
+  if (!uploadId) {
+    throw new Error('Upload ID is required');
+  }
+
+  const command = new AbortMultipartUploadCommand({
+    Bucket: bucket,
+    Key: key,
+    UploadId: uploadId,
+  });
+
+  await s3Client.send(command);
+
+  return {bucket, key, uploadId};
+}
+
+function buildObjectUrl(bucket, key) {
+  return `https://${bucket}.s3.${config.AWS_REGION}.amazonaws.com/${encodeURI(key)}`;
 }

--- a/nodeServer/services/s3UploadService.js
+++ b/nodeServer/services/s3UploadService.js
@@ -13,15 +13,6 @@ export function createS3Client(config) {
     region: config.AWS_REGION || config.region || 'ca-central-1',
   };
 
-  if (config.S3_ENDPOINT) {
-    clientConfig.endpoint = config.S3_ENDPOINT;
-    // For S3-compatible endpoints, use path style if necessary
-    clientConfig.forcePathStyle = config.S3_FORCE_PATH_STYLE === true;
-  }
-
-  // If explicit credentials are provided via config, use them. Otherwise
-  // the SDK will fall back to the default provider chain (env, shared
-  // credentials file, EC2/ECS/EKS role, etc.).
   if (config.AWS_ACCESS_KEY_ID && config.AWS_SECRET_ACCESS_KEY) {
     clientConfig.credentials = {
       accessKeyId: config.AWS_ACCESS_KEY_ID,
@@ -65,20 +56,8 @@ export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentTyp
 
   await s3Client.send(command);
 
-  // Construct a URL. If a custom endpoint is provided the SDK may not
-  // provide a convenient helper, so build a best-effort URL using
-  // standard S3 URL patterns.
-  let url;
-  if (s3Client.config && s3Client.config.endpoint) {
-    const endpoint = s3Client.config.endpoint;
-    const endpointStr = typeof endpoint === 'string' ? endpoint : (endpoint && endpoint.href) ? endpoint.href : String(endpoint);
-    url = `${endpointStr.replace(/\/+$/,'')}/${bucket}/${encodeURIComponent(key)}`;
-  } else {
-    const region = s3Client.config && s3Client.config.region ? s3Client.config.region : 'us-east-1';
-    // For us-east-1 the URL is slightly different, but using the generic
-    // pattern is sufficient for most cases here.
-    url = `https://${bucket}.s3.${region}.amazonaws.com/${encodeURIComponent(key)}`;
-  }
+  const region = s3Client.config && s3Client.config.region ? s3Client.config.region : 'us-east-1';
+  const url = `https://${bucket}.s3.${region}.amazonaws.com/${encodeURIComponent(key)}`;
 
   return {bucket, key, url};
 }

--- a/nodeServer/services/s3UploadService.js
+++ b/nodeServer/services/s3UploadService.js
@@ -1,13 +1,6 @@
 import {S3Client, PutObjectCommand} from '@aws-sdk/client-s3';
 import path from 'path';
 
-/**
- * Create an S3 client using config values. The AWS SDK default provider
- * chain will be used when explicit credentials are not provided.
- *
- * @param {object} config - configuration object with AWS_*/S3_* fields
- * @returns {S3Client}
- */
 export function createS3Client(config) {
   const clientConfig = {
     region: config.AWS_REGION || config.region || 'ca-central-1',

--- a/nodeServer/services/s3UploadService.js
+++ b/nodeServer/services/s3UploadService.js
@@ -1,9 +1,10 @@
 import {S3Client, PutObjectCommand} from '@aws-sdk/client-s3';
 import path from 'path';
+import config from "../config.js";
 
 export function createS3Client(config) {
   const clientConfig = {
-    region: config.AWS_REGION || config.region || 'ca-central-1',
+    region: config.AWS_REGION,
   };
 
   if (config.AWS_ACCESS_KEY_ID && config.AWS_SECRET_ACCESS_KEY) {
@@ -49,8 +50,7 @@ export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentTyp
 
   await s3Client.send(command);
 
-  const region = s3Client.config && s3Client.config.region ? s3Client.config.region : 'us-east-1';
-  const url = `https://${bucket}.s3.${region}.amazonaws.com/${encodeURIComponent(key)}`;
+  const url = `https://${bucket}.s3.${config.AWS_REGION}.amazonaws.com/${encodeURIComponent(key)}`;
 
   return {bucket, key, url};
 }

--- a/nodeServer/services/s3UploadService.js
+++ b/nodeServer/services/s3UploadService.js
@@ -1,0 +1,95 @@
+import {S3Client, PutObjectCommand} from '@aws-sdk/client-s3';
+import path from 'path';
+
+/**
+ * Create an S3 client using config values. The AWS SDK default provider
+ * chain will be used when explicit credentials are not provided.
+ *
+ * @param {object} config - configuration object with AWS_*/S3_* fields
+ * @returns {S3Client}
+ */
+export function createS3Client(config) {
+  const clientConfig = {
+    region: config.AWS_REGION || config.region || 'ca-central-1',
+  };
+
+  if (config.S3_ENDPOINT) {
+    clientConfig.endpoint = config.S3_ENDPOINT;
+    // For S3-compatible endpoints, use path style if necessary
+    clientConfig.forcePathStyle = config.S3_FORCE_PATH_STYLE === true;
+  }
+
+  // If explicit credentials are provided via config, use them. Otherwise
+  // the SDK will fall back to the default provider chain (env, shared
+  // credentials file, EC2/ECS/EKS role, etc.).
+  if (config.AWS_ACCESS_KEY_ID && config.AWS_SECRET_ACCESS_KEY) {
+    clientConfig.credentials = {
+      accessKeyId: config.AWS_ACCESS_KEY_ID,
+      secretAccessKey: config.AWS_SECRET_ACCESS_KEY,
+    };
+  }
+
+  return new S3Client(clientConfig);
+}
+
+/**
+ * Upload a buffer to S3 and return the object URL.
+ *
+ * @param {S3Client} s3Client
+ * @param {string} bucket
+ * @param {string} key
+ * @param {Buffer} buffer
+ * @param {string} contentType
+ * @param {boolean} publicRead
+ * @returns {Promise<{bucket:string,key:string,url:string}>}
+ */
+export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentType = 'application/octet-stream', publicRead = false) {
+  if (!bucket) {
+    const err = new Error('Bucket name is required');
+    err.code = 'MISSING_BUCKET';
+    throw err;
+  }
+
+  const params = {
+    Bucket: bucket,
+    Key: key,
+    Body: buffer,
+    ContentType: contentType,
+  };
+
+  if (publicRead) {
+    params.ACL = 'public-read';
+  }
+
+  const command = new PutObjectCommand(params);
+
+  await s3Client.send(command);
+
+  // Construct a URL. If a custom endpoint is provided the SDK may not
+  // provide a convenient helper, so build a best-effort URL using
+  // standard S3 URL patterns.
+  let url;
+  if (s3Client.config && s3Client.config.endpoint) {
+    const endpoint = s3Client.config.endpoint;
+    const endpointStr = typeof endpoint === 'string' ? endpoint : (endpoint && endpoint.href) ? endpoint.href : String(endpoint);
+    url = `${endpointStr.replace(/\/+$/,'')}/${bucket}/${encodeURIComponent(key)}`;
+  } else {
+    const region = s3Client.config && s3Client.config.region ? s3Client.config.region : 'us-east-1';
+    // For us-east-1 the URL is slightly different, but using the generic
+    // pattern is sufficient for most cases here.
+    url = `https://${bucket}.s3.${region}.amazonaws.com/${encodeURIComponent(key)}`;
+  }
+
+  return {bucket, key, url};
+}
+
+/**
+ * Helper to create a safe object key. Uses an optional folder/prefix and
+ * the original file name. Time-based prefix reduces collisions.
+ */
+export function makeObjectKey(originalName, prefix = '') {
+  const timestamp = Date.now();
+  const safeName = path.basename(originalName).replace(/[^a-zA-Z0-9._-]/g, '_');
+  const key = prefix ? `${prefix.replace(/\/+$/g, '')}/${timestamp}_${safeName}` : `${timestamp}_${safeName}`;
+  return key;
+}

--- a/nodeServer/services/s3UploadService.js
+++ b/nodeServer/services/s3UploadService.js
@@ -28,7 +28,7 @@ export function createS3Client(config) {
  * @param {boolean} publicRead
  * @returns {Promise<{bucket:string,key:string,url:string}>}
  */
-export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentType = 'application/octet-stream', publicRead = false) {
+export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentType = 'application/octet-stream', publicRead = true) {
   if (!bucket) {
     const err = new Error('Bucket name is required');
     err.code = 'MISSING_BUCKET';
@@ -50,7 +50,7 @@ export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentTyp
 
   await s3Client.send(command);
 
-  const url = `https://${bucket}.s3.${config.AWS_REGION}.amazonaws.com/${encodeURIComponent(key)}`;
+  const url = `https://${bucket}.s3.${config.AWS_REGION}.amazonaws.com/${encodeURI(key)}`;
 
   return {bucket, key, url};
 }
@@ -59,9 +59,10 @@ export async function uploadBufferToS3(s3Client, bucket, key, buffer, contentTyp
  * Helper to create a safe object key. Uses an optional folder/prefix and
  * the original file name. Time-based prefix reduces collisions.
  */
-export function makeObjectKey(originalName, prefix = '') {
+export function makeObjectKey(originalName) {
+  const pathInBucket = 'public/pdfs/';
   const timestamp = Date.now();
-  const safeName = path.basename(originalName).replace(/[^a-zA-Z0-9._-]/g, '_');
-  const key = prefix ? `${prefix.replace(/\/+$/g, '')}/${timestamp}_${safeName}` : `${timestamp}_${safeName}`;
+  const safeName = path.basename(String(originalName || '')).replace(/[^a-zA-Z0-9._-]/g, '_');
+  const key = `${pathInBucket}${timestamp}_${safeName}`;
   return key;
 }

--- a/nodeServer/test/s3UploadService.test.js
+++ b/nodeServer/test/s3UploadService.test.js
@@ -1,0 +1,145 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {
+  createPresignedPutUrl,
+  initiateMultipartUpload,
+  createPresignedUploadPartUrl,
+  completeMultipartUpload,
+  abortMultipartUpload,
+  makeObjectKey,
+} from '../services/s3UploadService.js';
+import config from '../config.js';
+import {
+  PutObjectCommand,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+  AbortMultipartUploadCommand,
+} from '@aws-sdk/client-s3';
+import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn(),
+}));
+
+function createMockS3Client(sendImplementation) {
+  return {
+    send: vi.fn(sendImplementation),
+  };
+}
+
+describe('s3UploadService presign and multipart helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a presigned PUT URL with expected parameters', async () => {
+    getSignedUrl.mockResolvedValue('https://example.com/presigned-put');
+    const mockClient = createMockS3Client();
+
+    const result = await createPresignedPutUrl(mockClient, {
+      bucket: 'test-bucket',
+      key: 'path/to/object.pdf',
+      contentType: 'application/pdf',
+      expiresInSeconds: 300,
+      publicRead: true,
+    });
+
+    expect(result.url).toBe('https://example.com/presigned-put');
+    expect(result.bucket).toBe('test-bucket');
+    expect(result.key).toBe('path/to/object.pdf');
+    expect(getSignedUrl).toHaveBeenCalledWith(expect.any(Object), expect.any(PutObjectCommand), {expiresIn: 300});
+  });
+
+  it('initiates multipart upload and returns upload id', async () => {
+    const mockClient = createMockS3Client((command) => {
+      if (command instanceof CreateMultipartUploadCommand) {
+        return Promise.resolve({UploadId: 'upload-123'});
+      }
+      return Promise.resolve();
+    });
+
+    const result = await initiateMultipartUpload(mockClient, {
+      bucket: 'bucket-name',
+      key: 'object-key',
+      contentType: 'application/pdf',
+      publicRead: false,
+    });
+
+    expect(result.uploadId).toBe('upload-123');
+    expect(mockClient.send).toHaveBeenCalledWith(expect.any(CreateMultipartUploadCommand));
+  });
+
+  it('creates presigned upload part URL for a given part number', async () => {
+    getSignedUrl.mockResolvedValue('https://example.com/presigned-part');
+    const mockClient = createMockS3Client();
+
+    const result = await createPresignedUploadPartUrl(mockClient, {
+      bucket: 'bucket-name',
+      key: 'object-key',
+      uploadId: 'upload-123',
+      partNumber: 2,
+      expiresInSeconds: 600,
+    });
+
+    expect(result.partNumber).toBe(2);
+    expect(result.url).toBe('https://example.com/presigned-part');
+    expect(getSignedUrl).toHaveBeenCalledWith(expect.any(Object), expect.any(UploadPartCommand), {expiresIn: 600});
+  });
+
+  it('completes multipart upload with sorted parts', async () => {
+    const receivedCommands = [];
+    const mockClient = createMockS3Client((command) => {
+      receivedCommands.push(command);
+      if (command instanceof CompleteMultipartUploadCommand) {
+        return Promise.resolve({Location: 'https://bucket-name.s3.region.amazonaws.com/object-key', ETag: 'abc'});
+      }
+      return Promise.resolve();
+    });
+
+    const result = await completeMultipartUpload(mockClient, {
+      bucket: 'bucket-name',
+      key: 'object-key',
+      uploadId: 'upload-123',
+      parts: [
+        {partNumber: 2, eTag: 'etag-2'},
+        {partNumber: 1, eTag: 'etag-1'},
+      ],
+    });
+
+    const completeCommand = receivedCommands.find((command) => command instanceof CompleteMultipartUploadCommand);
+    expect(completeCommand.input.MultipartUpload.Parts).toEqual([
+      {ETag: 'etag-1', PartNumber: 1},
+      {ETag: 'etag-2', PartNumber: 2},
+    ]);
+    expect(result.location).toContain('bucket-name');
+    expect(result.eTag).toBe('abc');
+  });
+
+  it('aborts multipart upload when requested', async () => {
+    const mockClient = createMockS3Client((command) => {
+      if (command instanceof AbortMultipartUploadCommand) {
+        return Promise.resolve({});
+      }
+      return Promise.resolve();
+    });
+
+    const result = await abortMultipartUpload(mockClient, {
+      bucket: 'bucket-name',
+      key: 'object-key',
+      uploadId: 'upload-123',
+    });
+
+    expect(result.uploadId).toBe('upload-123');
+    expect(mockClient.send).toHaveBeenCalledWith(expect.any(AbortMultipartUploadCommand));
+  });
+
+  it('builds object keys with configured prefix and sanitized names', () => {
+    const originalPrefix = config.S3_KEY_PREFIX;
+    config.S3_KEY_PREFIX = 'custom/prefix/';
+    const objectKey = makeObjectKey('unsafe name.pdf');
+    expect(objectKey.startsWith('custom/prefix/')).toBe(true);
+    expect(objectKey).toContain('_unsafe_name.pdf');
+    config.S3_KEY_PREFIX = originalPrefix;
+  });
+});
+


### PR DESCRIPTION
This pull request adds support for uploading PDF documents to S3 via the data management modal, including both single-part and multipart uploads, and integrates the necessary backend and frontend changes. It introduces a new `/uploads` route for handling S3 uploads, updates the modal UI to support PDF uploads for the `doc_url` field, and adds required dependencies for S3 and file upload handling.

**Backend: S3 Upload API Integration**
- Added a new `uploads.js` route that provides endpoints for presigned URL generation, multipart upload initiation, part upload, completion, and abort, as well as direct file uploads to S3. This includes authentication checks and file size validation.
- Registered the new `/uploads` route in the main `app.js` file. [[1]](diffhunk://#diff-466b3e6f02918b1a64b9dc67e568f0b4de6a31e2a472f52156fd6db7df804a79R16) [[2]](diffhunk://#diff-466b3e6f02918b1a64b9dc67e568f0b4de6a31e2a472f52156fd6db7df804a79R63)
- Added dependencies for AWS S3 SDK and `multer` to `package.json`.

**Frontend: Data Management Modal Enhancements**
- Updated `ModalRenderer` in `modalManager.js` to add a special UI for the `doc_url` field: users can either enter a URL or upload a PDF. The upload button handles both single-part and multipart uploads by interacting with the new backend endpoints, including error handling and status updates. [[1]](diffhunk://#diff-de8424ca3052421098caa96ceeca6bf29de2be4f803f8514f7668e406da29fb8R155-R363) [[2]](diffhunk://#diff-de8424ca3052421098caa96ceeca6bf29de2be4f803f8514f7668e406da29fb8R374)

**Documentation**
- Updated testing instructions in `TESTING.md` to clarify that Docker commands should be run from the project root directory.